### PR TITLE
Updated the link to the CERT sign up 

### DIFF
--- a/_newsroom/Tender Notices.md
+++ b/_newsroom/Tender Notices.md
@@ -10,4 +10,4 @@ For tender notices pertaining to available spaces for rent at Community Clubs/Ce
 Open Tenders published via the Grassroots Emart System 2 (GEMS 2) can be viewed online using [this](https://gems.pa.gov.sg/account/vendors) link. Access the GEMS 2 webpage to learn more.
 <br>
 
-Please check the below listing(s) for the latest tender notices: <br> [Tender for Woodlands CCC Trade Fair](/tender-details/woodlandsccctradefair)<br>[Tender for Kampong Glam CCC Trade Fair](/tender-details/kgccctf)<br>
+Please check the below listing(s) for the latest tender notices: <br> [Tender for Marsiling CCC Trade Fair ](/tender-details/mccctf)<br> [Tender for Woodlands CCC Trade Fair](/tender-details/woodlandsccctradefair)<br>[Tender for Kampong Glam CCC Trade Fair](/tender-details/kgccctf)<br>

--- a/_our-network/Grassroots Organisations/Community Emergency and Engagement Committees.md
+++ b/_our-network/Grassroots Organisations/Community Emergency and Engagement Committees.md
@@ -32,7 +32,4 @@ First formed in 2004 as part of the Residents’ Committees and Neighbourhood Co
 * Community Mediation Workshop
 * Community Vigilance Workshop
 
-#### To sign up as a CERT member, please contact us via [Registration Form](http://go.gov.sg/dzdaq0)
-
-
-
+#### To sign up as a CERT member, please sign up via the [Registration Form](http://go.gov.sg/dzdaq0)

--- a/_our-network/Grassroots Organisations/Community Emergency and Engagement Committees.md
+++ b/_our-network/Grassroots Organisations/Community Emergency and Engagement Committees.md
@@ -32,13 +32,7 @@ First formed in 2004 as part of the Residents’ Committees and Neighbourhood Co
 * Community Mediation Workshop
 * Community Vigilance Workshop
 
-#### To sign up as a CERT member:
+#### To sign up as a CERT member, please contact us via [Registration Form](http://go.gov.sg/dzdaq0)
 
-Please call 6340 5350 or drop us an 
-[email](PA_Cert@pa.gov.sg).
 
-You can also fax or mail your application to
-Emergency Preparedness Division
-9 King George’s Ave
-Singapore 208581
-Fax: 6440 2791
+

--- a/_our-network/Grassroots Organisations/Community Emergency and Engagement Committees.md
+++ b/_our-network/Grassroots Organisations/Community Emergency and Engagement Committees.md
@@ -32,4 +32,4 @@ First formed in 2004 as part of the Residents’ Committees and Neighbourhood Co
 * Community Mediation Workshop
 * Community Vigilance Workshop
 
-#### To sign up as a CERT member, please sign up via the [Registration Form](http://go.gov.sg/dzdaq0)
+#### To volunteer as a CERT member, please sign up via the [Registration Form](http://go.gov.sg/dzdaq0)

--- a/_tender-details/Tender for Marsiling CCC Trade Fair.md
+++ b/_tender-details/Tender for Marsiling CCC Trade Fair.md
@@ -1,0 +1,5 @@
+---
+title: Tender for Marsiling CCC Trade Fair
+permalink: /tender-details/mccctf/
+description: ""
+---

--- a/_tender-details/Tender for Marsiling CCC Trade Fair.md
+++ b/_tender-details/Tender for Marsiling CCC Trade Fair.md
@@ -3,3 +3,21 @@ title: Tender for Marsiling CCC Trade Fair
 permalink: /tender-details/mccctf/
 description: ""
 ---
+Tender for Marsiling CCC Trade Fair
+=======================================
+**Trade Fair Duration: 11 Aug to 26 Aug 2023 (16 days) <br>
+Venue:  Open space beside Bishan Bus Interchange** 
+
+**Calling Committee: Bishan East - Sin Ming Citizens’ Consultative Committee (CCC)** <br>
+**Publication Date : 1 Jun 2023** <br>
+**Closing Date &amp; Time : 15 Jun 2023, 06:00 PM**
+* * *
+### Details
+(1) For request of soft copy tender documents, please email to Jocelyn_Ng@pa.gov.sg.
+
+(2) For request of hard copy tender documents, please collect at Bishan Community Club reception counter located at 51 Bishan Street 13 Singapore 579799 during operating hours from 10.00am to 6.00pm daily, except Public Holidays.
+
+<br>
+For enquiries, please contact Jocelyn at Tel: 6259 4720 or email to Jocelyn_Ng@pa.gov.sg.
+
+

--- a/_tender-details/Tender for Marsiling CCC Trade Fair.md
+++ b/_tender-details/Tender for Marsiling CCC Trade Fair.md
@@ -10,12 +10,12 @@ Venue:  Open field beside Causeway Point**
 
 **Calling Committee: Marsiling Citizens’ Consultative Committee (CCC)** <br>
 **Publication Date : 7 Jul 2023** <br>
-**Closing Date &amp; Time : 21 Jul 2023, 06:00 PM**
+**Closing Date &amp; Time : 21 Jul 2023, 6.00 PM**
 * * *
 ### Details
 (1) For request of soft copy tender documents, please email to lawrence_chong@pa.gov.sg.
 
-(2) For request of hard copy tender documents, please collect at Bishan Community Club reception counter located at 51 Bishan Street 13 Singapore 579799 during operating hours from 10.00am to 6.00pm daily, except Public Holidays.
+(2) For request of hard copy tender documents, please collect at Marsiling Community Club reception counter located at 100 Admiralty Road, Singapore 739980 during operating hours from 10.00 am to 6.00 pm daily, except Public Holidays.
 
 <br>
-For enquiries, please contact Jocelyn at Tel: 6259 4720 or email to Jocelyn_Ng@pa.gov.sg.
+For enquiries, please contact Lawrence Chong at Tel: 6269 6768 or email to lawrence_chong@pa.gov.sg.

--- a/_tender-details/Tender for Marsiling CCC Trade Fair.md
+++ b/_tender-details/Tender for Marsiling CCC Trade Fair.md
@@ -5,12 +5,12 @@ description: ""
 ---
 Tender for Marsiling CCC Trade Fair
 =======================================
-**Trade Fair Duration: 11 Aug to 26 Aug 2023 (16 days) <br>
-Venue:  Open space beside Bishan Bus Interchange** 
+**Trade Fair Duration: 25 Sep to 24 Oct 2023 (30 days) <br>
+Venue:  Open field beside Causeway Point** 
 
-**Calling Committee: Bishan East - Sin Ming Citizens’ Consultative Committee (CCC)** <br>
-**Publication Date : 1 Jun 2023** <br>
-**Closing Date &amp; Time : 15 Jun 2023, 06:00 PM**
+**Calling Committee: Marsiling Citizens’ Consultative Committee (CCC)** <br>
+**Publication Date : 7 Jul 2023** <br>
+**Closing Date &amp; Time : 21 Jul 2023, 06:00 PM**
 * * *
 ### Details
 (1) For request of soft copy tender documents, please email to Jocelyn_Ng@pa.gov.sg.
@@ -19,5 +19,3 @@ Venue:  Open space beside Bishan Bus Interchange**
 
 <br>
 For enquiries, please contact Jocelyn at Tel: 6259 4720 or email to Jocelyn_Ng@pa.gov.sg.
-
-

--- a/_tender-details/Tender for Marsiling CCC Trade Fair.md
+++ b/_tender-details/Tender for Marsiling CCC Trade Fair.md
@@ -13,7 +13,7 @@ Venue:  Open field beside Causeway Point**
 **Closing Date &amp; Time : 21 Jul 2023, 06:00 PM**
 * * *
 ### Details
-(1) For request of soft copy tender documents, please email to Jocelyn_Ng@pa.gov.sg.
+(1) For request of soft copy tender documents, please email to lawrence_chong@pa.gov.sg.
 
 (2) For request of hard copy tender documents, please collect at Bishan Community Club reception counter located at 51 Bishan Street 13 Singapore 579799 during operating hours from 10.00am to 6.00pm daily, except Public Holidays.
 

--- a/_tender-details/collection.yml
+++ b/_tender-details/collection.yml
@@ -2,5 +2,6 @@ collections:
   tender-details:
     output: true
     order:
+      - Tender for Marsiling CCC Trade Fair.md
       - Tender for Woodlands CCC Trade Fair.md
       - Kampong Glam CCC Trade Fair.md


### PR DESCRIPTION
I updated the link to CERT sign up, and direct users via the Form.SG which is the sign up method on the Our Programmes. I also removed the information like mail us / Fax us because this is obslete. 