### PR TITLE
Change the contents for Be a Training Provider page

### DIFF
--- a/_our-programmes/CC Courses/Be a Training Provider.md
+++ b/_our-programmes/CC Courses/Be a Training Provider.md
@@ -9,11 +9,10 @@ variant: tiptap
 <img style="width: 100%" height="auto" width="100%" alt="Uplife Your PAssion to Inspire" src="/images/Our%20Programmes/web-banner.jpg">
 </div>
 <p></p>
-<h2><strong>Apply to be a PA Training Provider</strong></h2>
-<p>Thank you for your interest to be a Training Provider !</p>
-<p>The submission of New Trainer/Operator application has closed on 31 August
-2024. More information on the next application window will be available
-on this page once ready.</p>
-<p>For further enquiries and assistance, please email to <a href="mailto:PA_Talent_Times@pa.gov.sg" rel="noopener noreferrer nofollow" target="_blank">PA_Talent_Times@pa.gov.sg</a>
+<h2><strong>Apply to be a PA Trainer</strong></h2>
+<p>Trainer recruitment is temporarily on hold.</p>
+<p>We will provide updates on the next application window by first quarter
+of 2026 on this page once they are available.</p>
+<p>For further enquiries, please email to <a href="mailto:PA_Talent_Times@pa.gov.sg" rel="noopener noreferrer nofollow" target="_blank">PA_Talent_Times@pa.gov.sg</a>
 </p>
 <p>&nbsp;</p>


### PR DESCRIPTION
replace the contents of the page to update public that recruitment is on hold for now, till further notice.